### PR TITLE
feat(unpublish): User can see a link is disabled in edit mode (#1207)

### DIFF
--- a/packages/bodiless-components/src/Link/index.ts
+++ b/packages/bodiless-components/src/Link/index.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import asBodilessLink, { withoutLinkWhenLinkDataEmpty } from './asBodilessLink';
+import asBodilessLink, { withoutLinkWhenLinkDataEmpty, useIsLinkDisabled } from './asBodilessLink';
 import type { NormalHref } from './NormalHref';
 import type { AsBodilessLink, LinkData, Props } from './types';
 import DefaultNormalHref from './NormalHref';
@@ -23,6 +23,7 @@ export {
   asBodilessLink,
   DefaultNormalHref,
   withoutLinkWhenLinkDataEmpty,
+  useIsLinkDisabled,
   useEmptyLinkToggle,
   useGetLinkHref,
 };

--- a/packages/bodiless-components/src/Link/useGetLinkHref.ts
+++ b/packages/bodiless-components/src/Link/useGetLinkHref.ts
@@ -24,7 +24,7 @@ const ensureTrailingSlash = (href: string) => (href.endsWith('/') ? href : `${hr
  * contains href.
  * Can be used in a richtext item (slatenode), list (menu) item or link component itself.
  * @param node: content node object.
- * @returns href: sting or undefined.
+ * @returns href: string or undefined.
  */
 const useGetLinkHref = (node: ContentNode<any>) => {
   if (node.data === undefined) {

--- a/packages/bodiless-components/src/PageDisable/__tests__/pageDisable.test.tsx
+++ b/packages/bodiless-components/src/PageDisable/__tests__/pageDisable.test.tsx
@@ -13,7 +13,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render, mount } from 'enzyme';
+import { PageEditContext } from '@bodiless/core';
 import { asToken, A, HOC } from '@bodiless/fclasses';
 import { asBodilessLink } from '../../Link';
 import { withMockNode } from '../../../__tests__/helpers/MockContentNode';
@@ -52,15 +53,15 @@ const withPageLink = (pagePath: string) => asToken(
 )(A);
 
 describe('Disabled page', () => {
+  const PageLink1 = withPageLink('/all-disabled/');
+  const PageLink2 = withPageLink('/disabled-content-links/');
+  const PageLink3 = withPageLink('/disabled-menu-links/');
+  const PageLink4 = withPageLink('/all-enabled/');
+  const wrapper1 = render(<PageLink1 />);
+  const wrapper2 = render(<PageLink2 />);
+  const wrapper3 = render(<PageLink3 />);
+  const wrapper4 = render(<PageLink4 />);
   describe('Disabled content (non-menu) link', () => {
-    const PageLink1 = withPageLink('/all-disabled/');
-    const PageLink2 = withPageLink('/disabled-content-links/');
-    const PageLink3 = withPageLink('/disabled-menu-links/');
-    const PageLink4 = withPageLink('/all-enabled/');
-    const wrapper1 = render(<PageLink1 />);
-    const wrapper2 = render(<PageLink2 />);
-    const wrapper3 = render(<PageLink3 />);
-    const wrapper4 = render(<PageLink4 />);
     it('Renders without "href" if the link leads to disabled page', () => {
       expect(wrapper1.prop('href')).toBeUndefined();
       expect(wrapper2.prop('href')).toBeUndefined();
@@ -71,7 +72,16 @@ describe('Disabled page', () => {
     it('Renders as usual link if all page disabling options are enabled', () => {
       expect(wrapper4.prop('href')).toBeDefined();
     });
-  });
-  describe('Disabled menu item', () => {
+    it('Does not highlight disabled links in preview mode', () => {
+      const wrapper1 = mount(<PageLink1 />);
+      expect(wrapper1.hasClass('bl-link-disabled')).toBeFalsy();
+    });
+    it('Highlights disabled links in edit mode', () => {
+      let mockIsEdit: jest.SpyInstance;
+      mockIsEdit = jest.spyOn(PageEditContext.prototype, 'isEdit', 'get').mockReturnValue(true);
+      const wrapper1 = mount(<PageLink1 />);
+      expect(wrapper1.render().hasClass('bl-link-disabled')).toBeTruthy();
+      mockIsEdit.mockRestore();
+    });
   });
 });

--- a/packages/bodiless-ui/bodiless.tailwind.config.js
+++ b/packages/bodiless-ui/bodiless.tailwind.config.js
@@ -700,6 +700,10 @@ module.exports = {
         '.rotate-180deg': {
           transform: 'rotate(180deg)',
         },
+        '.link-disabled': {
+          outline: '3px #ff00d1 dashed',
+          'background-color': '#ff00d166',
+        },
       };
 
       const components = {


### PR DESCRIPTION
Co-authored-by: Ivan Rudiuk <IRudiuk@its.jnj.com>

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
